### PR TITLE
feat(header): basic header API

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -1,18 +1,34 @@
-// you can use this file to add your custom webpack plugins, loaders and anything you like.
-// This is just the basic way to add additional webpack configurations.
-// For more information refer the docs: https://storybook.js.org/configurations/custom-webpack-config
-
-// IMPORTANT
-// When you add this file, we won't add the default configurations which is similar
-// to "React Create App". This only has babel loader to load JavaScript.
+const path = require('path');
+const WebpackBuildNotifierPlugin = require('webpack-build-notifier');
 
 module.exports = {
   plugins: [
-    // your custom plugins
+    new WebpackBuildNotifierPlugin({
+      title: 'Header Storybook Build',
+      warningSound: true,
+      failureSound: true,
+    }),
   ],
+  devtool: 'source-map',
   module: {
     rules: [
-      // add your custom rules.
+      {
+        test: /\.css$/,
+        use: ['style-loader', 'css-loader'],
+      },
+      {
+        test: /\.(js|jsx)$/,
+        exclude: /(node_modules)/,
+        use: [
+          {
+            loader: 'babel-loader',
+            options: {
+              presets: ['env'],
+            },
+          },
+          { loader: 'source-map-loader' },
+        ],
+      },
     ],
   },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,42 @@
         "bootstrap": "4.0.0-beta.2",
         "jquery": "3.3.1",
         "popper.js": "1.12.9"
+      },
+      "dependencies": {
+        "bootstrap": {
+          "version": "4.0.0-beta.2",
+          "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.0.0-beta.2.tgz",
+          "integrity": "sha512-DzGtdTlKbrMoGMpz0LigKSqJ+MgtFKxA791PU/q062OlRG0HybNZcTLH7rpDAmLS66Y3esN9yzKHLLbqa5UR3w=="
+        }
+      }
+    },
+    "@fortawesome/fontawesome": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome/-/fontawesome-1.1.3.tgz",
+      "integrity": "sha512-zSKSJsYpV8jHUJYni6YNLN7pOcTBXG4sNVX4vXL6IJsqlwosyZm/IftWNOwbr4tbw3O1MxeY05TzYfjVB3T+QQ==",
+      "requires": {
+        "@fortawesome/fontawesome-common-types": "0.1.2"
+      }
+    },
+    "@fortawesome/fontawesome-common-types": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.1.2.tgz",
+      "integrity": "sha512-l6pzAz8wVL7Z6CD/hYN7593xogzMFfX04dwyniqDswT8whGSopSG3UMOIx7xkBFbnXTdRgi4/2tbwFXyBy2WBw=="
+    },
+    "@fortawesome/fontawesome-free-solid": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free-solid/-/fontawesome-free-solid-5.0.6.tgz",
+      "integrity": "sha512-vpysFybs2fWuI5RblDQX8r20vMX1Kc9yXmqoJ5RGOdRiXs105FLzJgGK1UlYf2NeECdvZ/O65Oo74oDgshpE7A==",
+      "requires": {
+        "@fortawesome/fontawesome-common-types": "0.1.2"
+      }
+    },
+    "@fortawesome/react-fontawesome": {
+      "version": "0.0.17",
+      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.0.17.tgz",
+      "integrity": "sha512-LpTGKuSVSMGzoKLph+d6l6rupPw17D1zX/dQYkryGdat9I76kwQwMYcn7ZviDDT6rTBlrdftB/1GIRvMSyPFuA==",
+      "requires": {
+        "humps": "2.0.1"
       }
     },
     "@storybook/addon-actions": {
@@ -186,6 +222,27 @@
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true
+        },
+        "style-loader": {
+          "version": "0.19.1",
+          "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-0.19.1.tgz",
+          "integrity": "sha512-IRE+ijgojrygQi3rsqT0U4dd+UcPCqcVvauZpCnQrGAlEe+FUIyrK93bUDScamesjP08JlQNsFJU+KmPedP5Og==",
+          "dev": true,
+          "requires": {
+            "loader-utils": "1.1.0",
+            "schema-utils": "0.3.0"
+          },
+          "dependencies": {
+            "schema-utils": {
+              "version": "0.3.0",
+              "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.3.0.tgz",
+              "integrity": "sha1-9YdyIs4+kx7a4DnxfrNxbnE3+M8=",
+              "dev": true,
+              "requires": {
+                "ajv": "5.5.2"
+              }
+            }
+          }
         },
         "uglify-es": {
           "version": "3.3.9",
@@ -1958,9 +2015,9 @@
       }
     },
     "bootstrap": {
-      "version": "4.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.0.0-beta.2.tgz",
-      "integrity": "sha512-DzGtdTlKbrMoGMpz0LigKSqJ+MgtFKxA791PU/q062OlRG0HybNZcTLH7rpDAmLS66Y3esN9yzKHLLbqa5UR3w=="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.0.0.tgz",
+      "integrity": "sha512-gulJE5dGFo6Q61V/whS6VM4WIyrlydXfCgkE+Gxe5hjrJ8rXLLZlALq7zq2RPhOc45PSwQpJkrTnc2KgD6cvmA=="
     },
     "bowser": {
       "version": "1.9.1",
@@ -2199,8 +2256,7 @@
     "chain-function": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/chain-function/-/chain-function-1.0.0.tgz",
-      "integrity": "sha1-DUqzfn4Y6tC9xHuSB2QRjOWHM9w=",
-      "dev": true
+      "integrity": "sha1-DUqzfn4Y6tC9xHuSB2QRjOWHM9w="
     },
     "chalk": {
       "version": "2.3.0",
@@ -2283,8 +2339,7 @@
     "classnames": {
       "version": "2.2.5",
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.5.tgz",
-      "integrity": "sha1-+zgB1FNGdknvNgPH1hoCvRKb3m0=",
-      "dev": true
+      "integrity": "sha1-+zgB1FNGdknvNgPH1hoCvRKb3m0="
     },
     "clean-css": {
       "version": "4.1.9",
@@ -3052,8 +3107,7 @@
     "dom-helpers": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.3.1.tgz",
-      "integrity": "sha512-2Sm+JaYn74OiTM2wHvxJOo3roiq/h25Yi69Fqk269cNUwIXsCvATB6CRSFC9Am/20G2b28hGv/+7NiWydIrPvg==",
-      "dev": true
+      "integrity": "sha512-2Sm+JaYn74OiTM2wHvxJOo3roiq/h25Yi69Fqk269cNUwIXsCvATB6CRSFC9Am/20G2b28hGv/+7NiWydIrPvg=="
     },
     "dom-serializer": {
       "version": "0.1.0",
@@ -4687,6 +4741,12 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
       "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
     },
+    "growly": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
+      "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
+      "dev": true
+    },
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
@@ -5005,6 +5065,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
       "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM="
+    },
+    "humps": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/humps/-/humps-2.0.1.tgz",
+      "integrity": "sha1-3QLqYIG9BWjcXQcxhEY5V7qe+ao="
     },
     "hyphenate-style-name": {
       "version": "1.0.2",
@@ -5536,6 +5601,16 @@
       "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
       "dev": true
     },
+    "lodash.isfunction": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-3.0.8.tgz",
+      "integrity": "sha1-TbcJ/IG8So/XEnpFilNGxc3OLGs="
+    },
+    "lodash.isobject": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-3.0.2.tgz",
+      "integrity": "sha1-PI+41bW/S/kK4G4U8qUwpO2TXh0="
+    },
     "lodash.isplainobject": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
@@ -5576,6 +5651,11 @@
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
       "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
       "dev": true
+    },
+    "lodash.tonumber": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.tonumber/-/lodash.tonumber-4.0.3.tgz",
+      "integrity": "sha1-C5azGzVnJ5Prf1pj7nkfG56QJdk="
     },
     "lodash.uniq": {
       "version": "4.5.0",
@@ -5926,6 +6006,18 @@
         "url": "0.11.0",
         "util": "0.10.3",
         "vm-browserify": "0.0.4"
+      }
+    },
+    "node-notifier": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.1.2.tgz",
+      "integrity": "sha1-L6nhJgX6EACdRFSdb82KY93g5P8=",
+      "dev": true,
+      "requires": {
+        "growly": "1.3.0",
+        "semver": "5.5.0",
+        "shellwords": "0.1.1",
+        "which": "1.3.0"
       }
     },
     "normalize-package-data": {
@@ -8463,6 +8555,15 @@
         "warning": "3.0.0"
       }
     },
+    "react-popper": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-0.7.5.tgz",
+      "integrity": "sha512-ya9dhhGCf74JTOB2uyksEHhIGw7w9tNZRUJF73lEq2h4H5JT6MBa4PdT4G+sx6fZwq+xKZAL/sVNAIuojPn7Dg==",
+      "requires": {
+        "popper.js": "1.12.9",
+        "prop-types": "15.6.0"
+      }
+    },
     "react-split-pane": {
       "version": "0.1.74",
       "resolved": "https://registry.npmjs.org/react-split-pane/-/react-split-pane-0.1.74.tgz",
@@ -8486,12 +8587,12 @@
       }
     },
     "react-transition-group": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-1.2.1.tgz",
-      "integrity": "sha512-CWaL3laCmgAFdxdKbhhps+c0HRGF4c+hdM4H23+FI1QBNUyx/AMeIJGWorehPNSaKnQNOAxL7PQmqMu78CDj3Q==",
-      "dev": true,
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.2.1.tgz",
+      "integrity": "sha512-q54UBM22bs/CekG8r3+vi9TugSqh0t7qcEVycaRc9M0p0aCEu+h6rp/RFiW7fHfgd1IKpd9oILFTl5QK+FpiPA==",
       "requires": {
         "chain-function": "1.0.0",
+        "classnames": "2.2.5",
         "dom-helpers": "3.3.1",
         "loose-envify": "1.3.1",
         "prop-types": "15.6.0",
@@ -8510,6 +8611,20 @@
         "radium": "0.19.6",
         "shallowequal": "0.2.2",
         "velocity-react": "1.3.3"
+      }
+    },
+    "reactstrap": {
+      "version": "5.0.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/reactstrap/-/reactstrap-5.0.0-alpha.4.tgz",
+      "integrity": "sha1-HenPOxY0TKmRIMKiDg79Sqrrwdg=",
+      "requires": {
+        "classnames": "2.2.5",
+        "lodash.isfunction": "3.0.8",
+        "lodash.isobject": "3.0.2",
+        "lodash.tonumber": "4.0.3",
+        "prop-types": "15.6.0",
+        "react-popper": "0.7.5",
+        "react-transition-group": "2.2.1"
       }
     },
     "read-pkg": {
@@ -8978,6 +9093,12 @@
         "rechoir": "0.6.2"
       }
     },
+    "shellwords": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
+      "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
+      "dev": true
+    },
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
@@ -9239,13 +9360,25 @@
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
     },
     "style-loader": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-0.19.1.tgz",
-      "integrity": "sha512-IRE+ijgojrygQi3rsqT0U4dd+UcPCqcVvauZpCnQrGAlEe+FUIyrK93bUDScamesjP08JlQNsFJU+KmPedP5Og==",
+      "version": "0.20.1",
+      "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-0.20.1.tgz",
+      "integrity": "sha512-NtlwQOHQvUgEKuPs4JoUMQUkML8UNMxLbXM2JAZerIQVVVMgO5VVRjYQA8zzkpBu/X2OnTt+5ZKe8IbGk5TjRA==",
       "dev": true,
       "requires": {
         "loader-utils": "1.1.0",
-        "schema-utils": "0.3.0"
+        "schema-utils": "0.4.3"
+      },
+      "dependencies": {
+        "schema-utils": {
+          "version": "0.4.3",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.4.3.tgz",
+          "integrity": "sha512-sgv/iF/T4/SewJkaVpldKC4WjSkz0JsOh2eKtxCPpCO1oR05+7MOF+H476HVRbLArkgA7j5TRJJ4p2jdFkUGQQ==",
+          "dev": true,
+          "requires": {
+            "ajv": "5.5.2",
+            "ajv-keywords": "2.1.1"
+          }
+        }
       }
     },
     "supports-color": {
@@ -9613,6 +9746,19 @@
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
           "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
           "dev": true
+        },
+        "react-transition-group": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-1.2.1.tgz",
+          "integrity": "sha512-CWaL3laCmgAFdxdKbhhps+c0HRGF4c+hdM4H23+FI1QBNUyx/AMeIJGWorehPNSaKnQNOAxL7PQmqMu78CDj3Q==",
+          "dev": true,
+          "requires": {
+            "chain-function": "1.0.0",
+            "dom-helpers": "3.3.1",
+            "loose-envify": "1.3.1",
+            "prop-types": "15.6.0",
+            "warning": "3.0.0"
+          }
         }
       }
     },
@@ -9645,7 +9791,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
       "integrity": "sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=",
-      "dev": true,
       "requires": {
         "loose-envify": "1.3.1"
       }
@@ -9722,6 +9867,17 @@
             "webpack-sources": "1.1.0"
           }
         }
+      }
+    },
+    "webpack-build-notifier": {
+      "version": "0.1.22",
+      "resolved": "https://registry.npmjs.org/webpack-build-notifier/-/webpack-build-notifier-0.1.22.tgz",
+      "integrity": "sha512-sdEVRkTgdRYltxoHkfSW6ARvb3LjeMzxPe4oc8aAr3ZhyGPIEShqi237lnEXWg6SeGN674UCBXN34+kvos4WFw==",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "2.1.1",
+        "node-notifier": "5.1.2",
+        "strip-ansi": "3.0.1"
       }
     },
     "webpack-dev-middleware": {

--- a/package.json
+++ b/package.json
@@ -13,9 +13,16 @@
   "license": "MIT",
   "dependencies": {
     "@edx/edx-bootstrap": "^0.4.3",
+    "@fortawesome/fontawesome": "^1.1.3",
+    "@fortawesome/fontawesome-free-solid": "^5.0.6",
+    "@fortawesome/react-fontawesome": "0.0.17",
+    "bootstrap": "^4.0.0",
+    "classnames": "^2.2.5",
     "prop-types": "^15.6.0",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
+    "react-transition-group": "^2.2.1",
+    "reactstrap": "^5.0.0-alpha.4",
     "webpack": "^3.10.0"
   },
   "devDependencies": {
@@ -28,7 +35,10 @@
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-preset-env": "^1.6.1",
     "babel-preset-react": "^6.24.1",
+    "css-loader": "^0.28.9",
     "source-map-loader": "^0.2.3",
-    "uglifyjs-webpack-plugin": "^1.1.8"
+    "style-loader": "^0.20.1",
+    "uglifyjs-webpack-plugin": "^1.1.8",
+    "webpack-build-notifier": "^0.1.22"
   }
 }

--- a/src/Header/Header.stories.jsx
+++ b/src/Header/Header.stories.jsx
@@ -2,7 +2,18 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 
 import Header from './index';
+import HeaderItem from '../HeaderItem';
 
 storiesOf('Header', module).add('basic usage', () => (
-  <Header />
+  <Header userIdentifier={'edx@example.com'}>
+    <HeaderItem title={'Courses'}>
+      <h4>Tab 1 Contents</h4>
+    </HeaderItem>
+    <HeaderItem title={'Programs'}>
+      <h4>Tab 2 Contents</h4>
+    </HeaderItem>
+    <HeaderItem title={'About'}>
+      <h4>Tab 3 Contents</h4>
+    </HeaderItem>
+  </Header>
 ));

--- a/src/Header/index.jsx
+++ b/src/Header/index.jsx
@@ -1,11 +1,90 @@
-import React from 'react';
+import React, { Component } from 'react';
+import {
+  Nav,
+  TabPane,
+  TabContent,
+  Row,
+  Col,
+  Media,
+ } from 'reactstrap';
 
-class Button extends React.Component {
+import classNames from 'classnames';
+
+import 'bootstrap/dist/css/bootstrap.css';
+
+import UserOptions from '../UserOptions';
+import HeaderItem from '../HeaderItem';
+import NavigationContent from '../NavigationContent';
+import HeaderContent from '../HeaderContent';
+
+import '../css/style.css';
+
+class Header extends Component {
+  constructor(props) {
+    super(props);
+
+    this.content = [];
+
+    this.toggle = this.toggle.bind(this);
+    this.onTabExit = this.onTabExit.bind(this);
+
+    this.state = { activeTab: null };
+  }
+
+  toggle(tabIndex) {
+    this.setState({ activeTab: tabIndex });
+  }
+
+  onTabExit() {
+    this.setState({ activeTab: null });
+  }
+
+  getContent() {
+    // TODO: @jaebradley - this is really hacky; was done to make external API clean
+    return React.Children.map(this.props.children, (item, index) => {
+      return React.Children.map(item.props.children, content => (
+        <TabPane tabId={index}>
+          <Row>
+            <Col sm='12'>
+              { content }
+            </Col>
+          </Row>
+        </TabPane>
+      ));
+    });
+  }
+
+  getItems() {
+    // TODO: @jaebradley - this is really hacky; was done to make external API clean
+    return React.Children.map(this.props.children, (item, index) => {
+      return React.cloneElement(item, {
+        children: [],
+        index,
+        onEnter: this.toggle,
+        onLeave: this.onTabExit,
+      });
+    });
+  }
+
   render() {
+    const content = this.getContent();
+    const items = this.getItems();
+
     return (
-      <div>hello world!</div>
+    <div className='header'>
+      <Nav tabs>
+        <Media className='icon' left>
+          <Media object src="https://www.edx.org/sites/default/files/theme/edx-logo-header.png" alt="Generic placeholder image" />
+        </Media>
+        { items }
+        <UserOptions userIdentifier={this.props.userIdentifier} />
+      </Nav>
+      <TabContent activeTab={this.state.activeTab}>
+        { content }
+      </TabContent>
+    </div>
     );
   }
 }
 
-export default Button;
+export default Header;

--- a/src/HeaderItem/index.jsx
+++ b/src/HeaderItem/index.jsx
@@ -1,0 +1,51 @@
+import React, { Component } from 'react';
+import classNames from 'classnames';
+import PropTypes from 'prop-types';
+import {
+  NavItem,
+  NavLink,
+} from 'reactstrap';
+
+import fontawesome from '@fortawesome/fontawesome';
+import FontAwesomeIcon from '@fortawesome/react-fontawesome';
+import { faCaretDown } from '@fortawesome/fontawesome-free-solid';
+
+fontawesome.library.add(faCaretDown);
+
+// TODO: @jaebradley - refactor this for public API usage
+class HeaderItem extends Component {
+  constructor(props) {
+    super(props);
+
+    this.onEnter = this.onEnter.bind(this);
+    this.onLeave = this.onLeave.bind(this);
+    this.onEnterCallback = props.onEnter.bind(this);
+    this.onLeaveCallback = props.onLeave.bind(this);
+
+    this.state = { active: false };
+  }
+
+  onEnter() {
+    this.setState({ active: true }, this.onEnterCallback(this.props.index));
+  }
+
+  onLeave() {
+    this.setState({ active: false }, this.onLeaveCallback);
+  }
+
+  render() {
+    return (
+      <NavItem className={classNames('header-item', { 'selected-nav-item': this.state.active })}>
+        <NavLink
+          onMouseEnter={ this.onEnter }
+          onMouseLeave={ this.onLeave }
+        >
+          { this.props.title }
+          <FontAwesomeIcon className='dropdown-icon' icon={'caret-down'} />
+        </NavLink>
+      </NavItem>
+    )
+  }
+}
+
+export default HeaderItem;

--- a/src/UserOptions/index.jsx
+++ b/src/UserOptions/index.jsx
@@ -1,0 +1,25 @@
+import React, { Component } from 'react';
+import {
+  UncontrolledDropdown,
+  DropdownToggle,
+ } from 'reactstrap';
+
+class UserOptions extends Component {
+  constructor(props) {
+    super(props);
+  }
+
+  render() {
+    return (
+      <div className='user-options'>
+        <UncontrolledDropdown nav innavbar='true'>
+          <DropdownToggle nav caret>
+            { this.props.userIdentifier }
+          </DropdownToggle>
+        </UncontrolledDropdown>
+      </div>
+    )
+  }
+}
+
+export default UserOptions;

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -1,0 +1,84 @@
+body {
+  font-family: "Open Sans",Arial,Helvetica,sans-serif;
+}
+
+.navbar {
+  padding-bottom: 0;
+  padding-top: 0;
+}
+
+.navbar-nav {
+  margin-left: 0px !important;
+}
+
+.content {
+  background: white;
+  color: #007db8;
+  height: 500px;
+  border-top-color: #007db8;
+  border-top-width: thick;
+  border-top: solid;
+  width: 500px;
+}
+
+.selected-nav-item {
+  background: #007db8;
+  color: white !important;
+}
+
+.user-options {
+  padding-left: 250px;
+}
+
+.user-options > .dropdown.nav-item {
+  float: left;
+}
+
+.user-options > .nav-item {
+  float: right;
+}
+
+.icon {
+  float: left;
+  padding: 10px;
+}
+
+.header {
+  height: 250px;
+}
+
+.nav-item {
+  padding: 20px;
+}
+
+.nav-link {
+  border: none !important;
+  border-top-left-radius: 0 !important;
+  border-top-right-radius: 0 !important;
+}
+
+.header-item {
+  color: #007db8;
+  font-size: 600;
+  line-height: 1.5em;
+  font-size: 18px;
+}
+
+.tab-content {
+  padding-left: 113px;
+}
+
+.tab-pane {
+  border-top: #007db8;
+  border-style: solid;
+  border-top-width: 2px;
+  border-right: none;
+  border-bottom: none;
+  border-left: none;
+  max-width: 700px;
+  min-height: 450px;
+}
+
+.dropdown-icon {
+  padding-left: 5px;
+}


### PR DESCRIPTION
### V1 of a Header API

![image](https://user-images.githubusercontent.com/8136030/35704966-133b85c6-076f-11e8-8f15-411e9282120c.png)

```javascript
<Header userIdentifier={'edx@example.com'}>
  <HeaderItem title={'Courses'}>
    <h4>Tab 1 Contents</h4>
  </HeaderItem>
  <HeaderItem title={'Programs'}>
    <h4>Tab 2 Contents</h4>
  </HeaderItem>
  <HeaderItem title={'About'}>
    <h4>Tab 3 Contents</h4>
  </HeaderItem>
</Header>
```

It wraps [`reactstrap`](reactstrap.github.io) which is a `Bootstrap`-based `React` library. There's a decent amount of stuff that's hard-coded but I wanted to get this out there for feedback and discussion.

Unless there are clear blockers, I think we should tackle as much add-on work in additional PRs vs. having an even bigger initial PR / commit (especially since we won't be publishing this yet), but I'm open to alternative tactics.